### PR TITLE
Refactor the chat message history

### DIFF
--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -2,11 +2,12 @@
 
 import { cn } from "@/utils/cn";
 import { Button } from "./ui/button";
-import { LoaderCircle } from "lucide-react";
+import { LoaderCircle, RefreshCw } from "lucide-react";
 import { FormEvent, ReactNode } from "react";
 
 export function ChatInput(props: {
   onSubmit: (e: FormEvent<HTMLFormElement>) => void;
+  onNewChat?: () => void;
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   loading?: boolean;
@@ -45,6 +46,18 @@ export function ChatInput(props: {
         
         <div className="absolute right-2 flex items-center gap-2">
           {props.children}
+          {props.onNewChat && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={props.onNewChat}
+              className="px-2"
+            >
+              <RefreshCw className="h-4 w-4" />
+              <span className="sr-only">New Chat</span>
+            </Button>
+          )}
           <Button 
             type="submit" 
             variant="default"

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -32,21 +32,25 @@ export function ChatInput(props: {
         e.preventDefault();
         props.onSubmit(e);
       }}
-      className={cn("flex w-full flex-col", props.className)}
+      className={cn("w-full max-w-[768px] mx-auto", props.className)}
     >
-      <div className="border border-input bg-secondary rounded-lg flex flex-col gap-2 max-w-[768px] w-full mx-auto">
+      <div className="relative flex items-center">
         <input
           value={props.value}
           placeholder={props.placeholder}
           onChange={props.onChange}
           onKeyDown={handleKeyDown}
-          className="border-none outline-none bg-transparent p-4"
+          className="w-full rounded-lg border border-input bg-secondary px-4 py-3 pr-20"
         />
-
-        <div className="flex justify-between ml-4 mr-2 mb-2">
-          <div className="flex gap-3">{props.children}</div>
-
-          <Button type="submit" className="self-end" disabled={props.loading}>
+        
+        <div className="absolute right-2 flex items-center gap-2">
+          {props.children}
+          <Button 
+            type="submit" 
+            variant="default"
+            size="sm" 
+            disabled={props.loading}
+          >
             {props.loading ? (
               <span role="status" className="flex justify-center">
                 <LoaderCircle className="animate-spin" />

--- a/components/ChatMessageBubble.tsx
+++ b/components/ChatMessageBubble.tsx
@@ -76,30 +76,6 @@ export function ChatMessageBubble(props: {
             {props.message.content}
           </Markdown>
         </div>
-
-        {props.sources && props.sources.length ? (
-          <>
-            <code className="mt-4 mr-auto bg-primary px-2 py-1 rounded">
-              <h2>🔍 Sources:</h2>
-            </code>
-            <code className="mt-1 mr-2 bg-primary px-2 py-1 rounded text-xs">
-              {props.sources?.map((source, i) => (
-                <div className="mt-2" key={"source:" + i}>
-                  {i + 1}. &quot;{source.pageContent}&quot;
-                  {source.metadata?.loc?.lines !== undefined ? (
-                    <div>
-                      <br />
-                      Lines {source.metadata?.loc?.lines?.from} to{" "}
-                      {source.metadata?.loc?.lines?.to}
-                    </div>
-                  ) : (
-                    ""
-                  )}
-                </div>
-              ))}
-            </code>
-          </>
-        ) : null}
       </div>
     </div>
   );

--- a/components/ChatMessageBubble.tsx
+++ b/components/ChatMessageBubble.tsx
@@ -7,21 +7,21 @@ export function ChatMessageBubble(props: {
   message: Message;
   aiEmoji?: string;
   sources: any[];
+  sessionId: string;
 }) {
   const handleLinkClick = useCallback(async (e: React.MouseEvent<HTMLAnchorElement>, href: string, text: string) => {
     // Don't interfere with normal link behavior
     // Just log the click in the background using sendBeacon which is more reliable for page transitions
     try {
-      const sessionId = localStorage.getItem('chatSessionId');
-      if (!sessionId) {
-        console.error('Session ID not found in localStorage (chatSessionId)');
+      if (!props.sessionId) {
+        console.error('No session ID provided');
         return;
       }
       
-      console.log('Logging link click for session:', sessionId, 'URL:', href);
+      console.log('Logging link click for session:', props.sessionId, 'URL:', href);
       
       const data = {
-        sessionId,
+        sessionId: props.sessionId,
         messageId: props.message.id,
         linkUrl: href,
         linkText: text
@@ -35,7 +35,7 @@ export function ChatMessageBubble(props: {
     } catch (error) {
       console.error('Failed to log link click:', error);
     }
-  }, [props.message.id]);
+  }, [props.message.id, props.sessionId]);
 
   return (
     <div

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -166,6 +166,8 @@ export function ChatWindow(props: {
   const startNewChat = () => {
     const newSessionId = uuidv4();
     setSessionId(newSessionId);
+    chat.setMessages([]); // Clear existing messages
+    chat.setInput(""); // Clear input field
   };
 
   const chat = useChat({
@@ -407,6 +409,7 @@ export function ChatWindow(props: {
               value={chat.input}
               onChange={chat.handleInputChange}
               onSubmit={sendMessage}
+              onNewChat={startNewChat}
               loading={chat.isLoading || intermediateStepsLoading}
               placeholder={
                 props.placeholder ?? "Enter your question here!"

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -14,6 +14,7 @@ import { Button } from "./ui/button";
 import { ArrowDown, LoaderCircle, Paperclip } from "lucide-react";
 import { Checkbox } from "./ui/checkbox";
 import { UploadDocumentsForm } from "./UploadDocumentsForm";
+import { ChatInput } from "./ChatInput";
 import {
   Dialog,
   DialogContent,
@@ -23,7 +24,7 @@ import {
   DialogTrigger,
 } from "./ui/dialog";
 import { cn } from "@/utils/cn";
-import { ChatHistory } from "@/components/ChatHistory";
+// import { ChatHistory } from "@/components/ChatHistory";
 
 function ChatMessages(props: {
   messages: Message[];
@@ -31,6 +32,7 @@ function ChatMessages(props: {
   sourcesForMessages: Record<string, any>;
   aiEmoji?: string;
   className?: string;
+  sessionId: string;
 }) {
   return (
     <div className="flex flex-col max-w-[768px] mx-auto pb-12 w-full">
@@ -46,6 +48,7 @@ function ChatMessages(props: {
             message={m}
             aiEmoji={props.aiEmoji}
             sources={props.sourcesForMessages[sourceKey]}
+            sessionId={props.sessionId}
           />
         );
       })}
@@ -66,62 +69,6 @@ function ScrollToBottom(props: { className?: string }) {
       <ArrowDown className="w-4 h-4" />
       <span>Scroll to bottom</span>
     </Button>
-  );
-}
-
-function ChatInput(props: {
-  onSubmit: (e: FormEvent<HTMLFormElement>) => void;
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  loading?: boolean;
-  placeholder?: string;
-  children?: ReactNode;
-  className?: string;
-}) {
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      const form = e.currentTarget.form;
-      if (form) {
-        props.onSubmit(new Event('submit') as unknown as FormEvent<HTMLFormElement>);
-      }
-    }
-  };
-
-  return (
-    <form
-      onSubmit={(e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        props.onSubmit(e);
-      }}
-      className={cn("flex w-full flex-col", props.className)}
-    >
-      <div className="border border-input bg-secondary rounded-lg flex flex-col gap-2 max-w-[768px] w-full mx-auto">
-        <input
-          value={props.value}
-          placeholder={props.placeholder}
-          onChange={props.onChange}
-          onKeyDown={handleKeyDown}
-          className="border-none outline-none bg-transparent p-4"
-        />
-
-        <div className="flex justify-between ml-4 mr-2 mb-2">
-          <div className="flex gap-3">{props.children}</div>
-
-          <Button type="submit" className="self-end" disabled={props.loading}>
-            {props.loading ? (
-              <span role="status" className="flex justify-center">
-                <LoaderCircle className="animate-spin" />
-                <span className="sr-only">Loading...</span>
-              </span>
-            ) : (
-              <span>Send</span>
-            )}
-          </Button>
-        </div>
-      </div>
-    </form>
   );
 }
 
@@ -169,51 +116,13 @@ export function ChatWindow(props: {
   
   // Add sessionId state
   const [sessionId, setSessionId] = useState<string | null>(null);
-  const [isLoadingHistory, setIsLoadingHistory] = useState(false);
 
-  // Initialize sessionId from localStorage or create a new one
+  // Initialize with a new session ID every time
   useEffect(() => {
-    console.log("Initializing session from localStorage or creating new one");
-    const savedSessionId = localStorage.getItem("chatSessionId");
-    if (savedSessionId) {
-      console.log("Found existing session ID:", savedSessionId);
-      setSessionId(savedSessionId);
-      loadChatHistory(savedSessionId);
-    } else {
-      const newSessionId = uuidv4();
-      console.log("Created new session ID:", newSessionId);
-      setSessionId(newSessionId);
-      localStorage.setItem("chatSessionId", newSessionId);
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    const newSessionId = uuidv4();
+    console.log("Created new session ID:", newSessionId);
+    setSessionId(newSessionId);
   }, []);
-
-  const loadChatHistory = async (sid: string) => {
-    if (!sid) return;
-    
-    try {
-      console.log("Loading chat history for session:", sid);
-      setIsLoadingHistory(true);
-      const response = await fetch(`/api/chat/history?sessionId=${sid}`);
-      
-      if (!response.ok) {
-        throw new Error("Failed to load chat history");
-      }
-      
-      const data = await response.json();
-      console.log("History data received:", data);
-      
-      if (data.messages && data.messages.length > 0) {
-        console.log("Setting messages from history:", data.messages);
-        chat.setMessages(data.messages);
-      }
-    } catch (error) {
-      console.error("Error loading chat history:", error);
-      toast.error("Failed to load chat history");
-    } finally {
-      setIsLoadingHistory(false);
-    }
-  };
 
   const saveChatMessages = async (messages: Message[]) => {
     if (!sessionId || messages.length === 0) {
@@ -252,16 +161,11 @@ export function ChatWindow(props: {
 
   const handleSelectSession = (selectedSessionId: string) => {
     setSessionId(selectedSessionId);
-    localStorage.setItem("chatSessionId", selectedSessionId);
-    loadChatHistory(selectedSessionId);
   };
 
   const startNewChat = () => {
     const newSessionId = uuidv4();
     setSessionId(newSessionId);
-    localStorage.setItem("chatSessionId", newSessionId);
-    chat.setMessages([]);
-    setSourcesForMessages({});
   };
 
   const chat = useChat({
@@ -287,11 +191,7 @@ export function ChatWindow(props: {
         });
       }
     },
-    onFinish(message) {
-      // This is called when the AI response is complete
-      console.log("Chat onFinish callback triggered with message:", message);
-      console.log("Current messages in chat:", chat.messages);
-      
+    onFinish(message) {      
       // Save the entire conversation including the AI's response
       if (chat.messages.length > 1 && sessionId) {
         // Check that we have at least one user and one assistant message
@@ -299,7 +199,6 @@ export function ChatWindow(props: {
         const hasAssistantMessage = chat.messages.some(m => m.role === "assistant");
         
         if (hasUserMessage && hasAssistantMessage) {
-          console.log("Saving complete conversation from onFinish callback");
           saveChatMessages(chat.messages);
         } else {
           console.log("Not saving from onFinish - missing user or assistant message");
@@ -470,7 +369,7 @@ export function ChatWindow(props: {
 
   // Add an effect to watch for changes to chat.messages and save them
   useEffect(() => {
-    if (chat.messages.length > 0 && !chat.isLoading && !isLoadingHistory) {
+    if (chat.messages.length > 0 && !chat.isLoading) {
       console.log("Messages changed, current count:", chat.messages.length);
       
       // Check if we have an assistant message (meaning we have a complete exchange)
@@ -489,14 +388,7 @@ export function ChatWindow(props: {
         className="absolute inset-0"
         contentClassName="py-8 px-2"
         content={
-          isLoadingHistory ? (
-            <div className="flex justify-center items-center h-full">
-              <div className="text-center">
-                <LoaderCircle className="animate-spin h-8 w-8 mx-auto mb-2" />
-                <p>Loading chat history...</p>
-              </div>
-            </div>
-          ) : chat.messages.length === 0 ? (
+          chat.messages.length === 0 ? (
             <div>{props.emptyStateComponent}</div>
           ) : (
             <ChatMessages
@@ -504,6 +396,7 @@ export function ChatWindow(props: {
               messages={chat.messages}
               emptyStateComponent={props.emptyStateComponent}
               sourcesForMessages={sourcesForMessages}
+              sessionId={sessionId || ''}
             />
           )
         }
@@ -514,12 +407,12 @@ export function ChatWindow(props: {
               value={chat.input}
               onChange={chat.handleInputChange}
               onSubmit={sendMessage}
-              loading={chat.isLoading || intermediateStepsLoading || isLoadingHistory}
+              loading={chat.isLoading || intermediateStepsLoading}
               placeholder={
                 props.placeholder ?? "Enter your question here!"
               }
             >
-              <ChatHistory onSelectSession={handleSelectSession} />
+              {/* <ChatHistory onSelectSession={handleSelectSession} />
               
               <Button 
                 variant="ghost" 
@@ -528,7 +421,7 @@ export function ChatWindow(props: {
                 disabled={chat.messages.length === 0}
               >
                 <span>New Chat</span>
-              </Button>
+              </Button> */}
 
               {props.showIngestForm && (
                 <Dialog>


### PR DESCRIPTION
# Refactor the chat message history

- Per discussion with the team, the chat history feature should be disabled. We refactor to remove chat history loading and start a new session upon reloading the page.
- We also want to restrict the creation of a new session in the database to when the user sends their first message (e.g. if they open the application but do not send a message, we don't want a session to be logged.)
- We add a refresh button to start a new chat within the chat window, which also creates a new session.
- We remove the "sources" block which is used for debugging from production.
- We check to ensure duplicate messages are not being stored.
