### PR TITLE
Improve admin dashboard dark mode styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,11 @@ The script will:
 - Split the content into chunks with appropriate overlap
 - Generate embeddings using OpenAI
 - Store the embeddings in your Supabase vector database
+
+## Admin Dashboard
+
+To access the admin dashboard for viewing conversation analytics and managing documents:
+
+1. Navigate to the Supabase dashboard and add a new user under `Authentication` with an email and password. Currently only admins have individual user accounts, whereas users access without an account, therefore *any user created in Supabase Authentication is automatically considered an admin*.
+2. Navigate to `/admin` or click the `Admin Login` button in the navbar.
+3. Sign in with admin credentials.

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -57,7 +57,7 @@ export default function AdminDashboard() {
 
   const renderHeader = (subtitle?: string) => (
     <div>
-      <h2 className="text-2xl font-bold">ChatPPC Admin Dashboard</h2>
+      <h2 className="text-2xl font-bold text-foreground">ChatPPC Admin Dashboard</h2>
       {subtitle && (
         <p className={subtitle?.startsWith('Error:') ? 'text-destructive' : 'text-muted-foreground'}>
           {subtitle}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -72,7 +72,7 @@ export default function RootLayout({
                 <Logo />
               </a> */}
               <nav className="flex gap-1 flex-row md:flex-row">
-                <Link href="/" className="[color:rgb(128,37,34)]"><strong>ChatPPC</strong></Link>
+                <Link href="/" className="text-red-800 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300"><strong>ChatPPC</strong></Link>
               </nav>
               <Button asChild variant="outline" size="default" className="w-fit">
                 <a

--- a/components/admin/ConversationDetail.tsx
+++ b/components/admin/ConversationDetail.tsx
@@ -54,10 +54,10 @@ export function ConversationDetail({ conversationId, onClose }: ConversationDeta
 
   if (loading) {
     return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={onClose}>
-        <div className="bg-white rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden" onClick={(e) => e.stopPropagation()}>
+      <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50" onClick={onClose}>
+        <div className="bg-background rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-semibold">Conversation Details</h2>
+            <h2 className="text-xl font-semibold text-foreground">Conversation Details</h2>
             <Button variant="ghost" size="sm" onClick={onClose}>
               <X className="h-4 w-4" />
             </Button>
@@ -70,10 +70,10 @@ export function ConversationDetail({ conversationId, onClose }: ConversationDeta
 
   if (error) {
     return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={onClose}>
-        <div className="bg-white rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden" onClick={(e) => e.stopPropagation()}>
+      <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50" onClick={onClose}>
+        <div className="bg-background rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-semibold">Conversation Details</h2>
+            <h2 className="text-xl font-semibold text-foreground">Conversation Details</h2>
             <Button variant="ghost" size="sm" onClick={onClose}>
               <X className="h-4 w-4" />
             </Button>
@@ -88,11 +88,11 @@ export function ConversationDetail({ conversationId, onClose }: ConversationDeta
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={onClose}>
-      <div className="bg-white rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col" onClick={(e) => e.stopPropagation()}>
+    <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50" onClick={onClose}>
+      <div className="bg-background rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between mb-4">
           <div>
-            <h2 className="text-xl font-semibold">Session {conversationDetail?.session.id.slice(0, 8)}</h2>
+            <h2 className="text-xl font-semibold text-foreground">Session {conversationDetail?.session.id.slice(0, 8)}</h2>
             <p className="text-sm text-muted-foreground">
               Started: {conversationDetail && formatDate(conversationDetail.session.created_at)}
             </p>
@@ -114,22 +114,22 @@ export function ConversationDetail({ conversationId, onClose }: ConversationDeta
         </div>
 
         <div className="flex-1 overflow-y-auto space-y-4">
-          <h3 className="font-medium sticky top-0 bg-white py-2">Messages</h3>
+          <h3 className="font-medium sticky top-0 bg-background py-2 text-foreground">Messages</h3>
           {conversationDetail?.messages.map((message) => (
             <div key={message.id} className={`flex gap-3 ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}>
               <div className={`flex gap-3 max-w-[80%] ${message.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}>
                 <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
                   message.role === 'user' 
-                    ? 'bg-blue-100 text-blue-600' 
-                    : 'bg-gray-100 text-gray-600'
+                    ? 'bg-primary/10 text-primary' 
+                    : 'bg-muted text-muted-foreground'
                 }`}>
                   {message.role === 'user' ? <User className="h-4 w-4" /> : <Bot className="h-4 w-4" />}
                 </div>
                 
                 <div className={`rounded-lg p-3 ${
                   message.role === 'user' 
-                    ? 'bg-blue-500 text-white' 
-                    : 'bg-gray-100 text-gray-900'
+                    ? 'bg-secondary text-secondary-foreground' 
+                    : 'bg-secondary text-secondary-foreground'
                 }`}>
                   <div className="text-sm leading-relaxed whitespace-pre-wrap">
                     {message.content}
@@ -144,7 +144,7 @@ export function ConversationDetail({ conversationId, onClose }: ConversationDeta
                     </details>
                   )}
                   
-                  <div className={`text-xs mt-2 opacity-75 ${message.role === 'user' ? 'text-blue-100' : 'text-gray-500'}`}>
+                  <div className={`text-xs mt-2 opacity-75 ${message.role === 'user' ? 'text-secondary-foreground' : 'text-secondary-foreground'}`}>
                     {formatDate(message.created_at)}
                   </div>
                 </div>

--- a/components/admin/Conversations.tsx
+++ b/components/admin/Conversations.tsx
@@ -171,8 +171,8 @@ export function Conversations({ stats }: ConversationsProps) {
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         {statCards.map((card) => (
           <div key={card.title} className="rounded-lg border bg-card p-6">
-            <h3 className="text-lg font-semibold">{card.title}</h3>
-            <p className="text-2xl font-bold mt-2">{card.value}</p>
+            <h3 className="text-lg font-semibold text-foreground">{card.title}</h3>
+            <p className="text-2xl font-bold mt-2 text-foreground">{card.value}</p>
             <p className="text-sm text-muted-foreground">{card.description}</p>
           </div>
         ))}
@@ -180,7 +180,7 @@ export function Conversations({ stats }: ConversationsProps) {
       
       <div className="rounded-lg border bg-card p-6">
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold">Recent Conversations</h3>
+          <h3 className="text-lg font-semibold text-foreground">Recent Conversations</h3>
         </div>
         
         <div className="flex items-center justify-between mb-4">
@@ -200,7 +200,7 @@ export function Conversations({ stats }: ConversationsProps) {
                       handleSearchSubmit()
                     }
                   }}
-                  className="w-64 pl-10 pr-10 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-64 pl-10 pr-10 py-2 border border-input rounded-md text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
                   disabled={loading}
                 />
                 {searchQuery && (
@@ -243,7 +243,7 @@ export function Conversations({ stats }: ConversationsProps) {
               <select 
                 value={pagination.limit}
                 onChange={(e) => handlePageSizeChange(Number(e.target.value))}
-                className="border border-gray-300 rounded px-2 py-1 text-sm bg-white min-w-[60px]"
+                className="border border-input rounded px-2 py-1 text-sm bg-background min-w-[60px]"
                 disabled={loading}
               >
                 {PAGE_SIZE_OPTIONS.map(size => (
@@ -282,18 +282,18 @@ export function Conversations({ stats }: ConversationsProps) {
                   onClick={() => setSelectedConversationId(conversation.id)}
                 >
                   <div className="flex-1">
-                    <p className="font-medium">Session {conversation.id.slice(0, 8)}</p>
+                    <p className="font-medium text-foreground">Session {conversation.id.slice(0, 8)}</p>
                     <p className="text-sm text-muted-foreground mb-1">
                       {conversation.message_count} messages • Created: {formatDate(conversation.created_at)} • Last Updated: {formatDate(conversation.updated_at)}
                     </p>
                     {conversation.first_message && (
-                      <p className="text-sm text-gray-600 italic">
+                      <p className="text-sm text-muted-foreground italic">
                         &ldquo;{conversation.first_message.content}&rdquo;
                       </p>
                     )}
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">
+                    <span className="text-xs bg-primary/10 text-primary px-2 py-1 rounded">
                       Click to view
                     </span>
                   </div>
@@ -343,7 +343,7 @@ export function Conversations({ stats }: ConversationsProps) {
 
       <div className="rounded-lg border bg-card p-6">
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold">Most Clicked Links</h3>
+          <h3 className="text-lg font-semibold text-foreground">Most Clicked Links</h3>
         </div>
         
         <div className="flex items-center justify-between mb-4">
@@ -363,7 +363,7 @@ export function Conversations({ stats }: ConversationsProps) {
                       handleLinkSearchSubmit()
                     }
                   }}
-                  className="w-64 pl-10 pr-10 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  className="w-64 pl-10 pr-10 py-2 border border-input rounded-md text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent"
                   disabled={linkClicksLoading}
                 />
                 {linkSearchQuery && (
@@ -406,7 +406,7 @@ export function Conversations({ stats }: ConversationsProps) {
               <select 
                 value={linkClicksPagination.limit}
                 onChange={(e) => handleLinkClicksPageSizeChange(Number(e.target.value))}
-                className="border border-gray-300 rounded px-2 py-1 text-sm bg-white min-w-[60px]"
+                className="border border-input rounded px-2 py-1 text-sm bg-background min-w-[60px]"
                 disabled={linkClicksLoading}
               >
                 {PAGE_SIZE_OPTIONS.map(size => (
@@ -450,7 +450,7 @@ export function Conversations({ stats }: ConversationsProps) {
                           href={link.url} 
                           target="_blank" 
                           rel="noopener noreferrer"
-                          className="text-blue-600 hover:text-blue-800 font-medium flex items-center gap-1"
+                          className="text-primary hover:text-primary/80 font-medium flex items-center gap-1"
                         >
                           {link.text}
                           <ExternalLink className="h-3 w-3 flex-shrink-0" />

--- a/components/admin/Conversations.tsx
+++ b/components/admin/Conversations.tsx
@@ -60,7 +60,7 @@ export function Conversations({ stats }: ConversationsProps) {
   const [conversations, setConversations] = useState<Conversation[]>([])
   const [pagination, setPagination] = useState({
     page: 1,
-    limit: 10,
+    limit: 5,
     total: 0,
     pages: 0
   })

--- a/components/admin/DocumentDetail.tsx
+++ b/components/admin/DocumentDetail.tsx
@@ -49,10 +49,10 @@ export function DocumentDetail({ source, title, onClose }: DocumentDetailProps) 
 
   if (loading) {
     return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={onClose}>
-        <div className="bg-white rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden" onClick={(e) => e.stopPropagation()}>
+      <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50" onClick={onClose}>
+        <div className="bg-background rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-semibold">Chunk Details</h2>
+            <h2 className="text-xl font-semibold text-foreground">Chunk Details</h2>
             <Button variant="ghost" size="sm" onClick={onClose}>
               <X className="h-4 w-4" />
             </Button>
@@ -65,10 +65,10 @@ export function DocumentDetail({ source, title, onClose }: DocumentDetailProps) 
 
   if (error) {
     return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={onClose}>
-        <div className="bg-white rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden" onClick={(e) => e.stopPropagation()}>
+      <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50" onClick={onClose}>
+        <div className="bg-background rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-semibold">Chunk Details</h2>
+            <h2 className="text-xl font-semibold text-foreground">Chunk Details</h2>
             <Button variant="ghost" size="sm" onClick={onClose}>
               <X className="h-4 w-4" />
             </Button>
@@ -83,11 +83,11 @@ export function DocumentDetail({ source, title, onClose }: DocumentDetailProps) 
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={onClose}>
-      <div className="bg-white rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col" onClick={(e) => e.stopPropagation()}>
+    <div className="fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50" onClick={onClose}>
+      <div className="bg-background rounded-lg p-6 w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between mb-4">
           <div>
-            <h2 className="text-xl font-semibold">{title}</h2>
+            <h2 className="text-xl font-semibold text-foreground">{title}</h2>
             {source !== title && (
               <p className="text-sm text-muted-foreground">{source}</p>
             )}
@@ -110,7 +110,7 @@ export function DocumentDetail({ source, title, onClose }: DocumentDetailProps) 
             <div className="border-t border-muted-foreground/20 pt-3">
               <div className="flex flex-wrap gap-2">
                 {Object.entries(documentDetail.chunks[0].metadata).map(([key, value]) => (
-                  <span key={key} className="text-xs bg-white border px-2 py-1 rounded">
+                  <span key={key} className="text-xs bg-background border px-2 py-1 rounded">
                     <strong>{key}:</strong> {
                       typeof value === 'object' && value !== null 
                         ? JSON.stringify(value)
@@ -124,10 +124,10 @@ export function DocumentDetail({ source, title, onClose }: DocumentDetailProps) 
         </div>
 
         <div className="flex-1 overflow-y-auto space-y-4">
-          <h3 className="font-medium sticky top-0 bg-white py-2">Content</h3>
+          <h3 className="font-medium sticky top-0 bg-background py-2 text-foreground">Content</h3>
           {documentDetail?.chunks.map((chunk) => (
             <div key={chunk.id} className="border rounded-lg p-4">
-              <div className="text-sm leading-relaxed prose prose-sm max-w-none">
+              <div className="text-sm leading-relaxed prose prose-sm prose-slate dark:prose-invert max-w-none">
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>
                   {chunk.content}
                 </ReactMarkdown>

--- a/components/admin/DocumentManagement.tsx
+++ b/components/admin/DocumentManagement.tsx
@@ -67,7 +67,7 @@ export function DocumentManagement() {
     <div className="space-y-6">
       <div className="rounded-lg border bg-card p-6">
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold">Document Management</h3>
+          <h3 className="text-lg font-semibold text-foreground">Document Management</h3>
         </div>
         
         {loading && !documentStats && (
@@ -92,8 +92,8 @@ export function DocumentManagement() {
                 <div className="space-y-3 mb-4">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
-                      <h4 className="font-medium">Chunks</h4>
-                      <span className="bg-blue-100 text-blue-800 text-xs font-medium px-2 py-1 rounded-full">
+                      <h4 className="font-medium text-foreground">Chunks</h4>
+                      <span className="bg-primary/10 text-primary text-xs font-medium px-2 py-1 rounded-full">
                         {pagination.total}
                       </span>
                     </div>
@@ -102,7 +102,7 @@ export function DocumentManagement() {
                       <select 
                         value={pagination.limit}
                         onChange={(e) => handlePageSizeChange(Number(e.target.value))}
-                        className="border border-gray-300 rounded px-2 py-1 text-sm bg-white min-w-[60px]"
+                        className="border border-input rounded px-2 py-1 text-sm bg-background min-w-[60px]"
                         disabled={loading}
                       >
                         {PAGE_SIZE_OPTIONS.map(size => (
@@ -127,13 +127,13 @@ export function DocumentManagement() {
                     >
                       <div className="flex items-center justify-between">
                         <div className="flex-1">
-                          <h5 className="font-medium mb-1">{doc.title}</h5>
+                          <h5 className="font-medium mb-1 text-foreground">{doc.title}</h5>
                           {doc.source !== doc.title && (
                             <p className="text-sm text-muted-foreground mb-2">{doc.source}</p>
                           )}
                           <p className="text-sm text-muted-foreground mt-2">{doc.content}</p>
                         </div>
-                        <span className="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded ml-4">
+                        <span className="text-xs bg-primary/10 text-primary px-2 py-1 rounded ml-4">
                           ID: {doc.id}
                         </span>
                       </div>

--- a/components/admin/DocumentManagement.tsx
+++ b/components/admin/DocumentManagement.tsx
@@ -30,7 +30,7 @@ export function DocumentManagement() {
   const [selectedDocument, setSelectedDocument] = useState<Document | null>(null)
   const [pagination, setPagination] = useState({
     page: 1,
-    limit: 10,
+    limit: 5,
     total: 0,
     pages: 0
   })


### PR DESCRIPTION
## Summary
- Fix hard-coded colors that caused readability issues in dark mode
- Update modal backgrounds and text contrast for better visibility
- Replace blue/gray colors with semantic Tailwind classes

## Test plan
- [x] Verify admin dashboard displays correctly in light mode
- [x] Verify admin dashboard displays correctly in dark mode
- [x] Test modal dialogs (conversation detail, document detail) in both modes
- [x] Confirm all text is readable and has proper contrast