### PR TITLE
Fix document detail modal to show specific chunk instead of all chunks

### DIFF
--- a/components/admin/DocumentDetail.tsx
+++ b/components/admin/DocumentDetail.tsx
@@ -21,27 +21,27 @@ interface DocumentDetail {
 }
 
 interface DocumentDetailProps {
-  source: string
+  chunkId: string
   title: string
   onClose: () => void
 }
 
-export function DocumentDetail({ source, title, onClose }: DocumentDetailProps) {
-  const [documentDetail, setDocumentDetail] = useState<DocumentDetail | null>(null)
+export function DocumentDetail({ chunkId, title, onClose }: DocumentDetailProps) {
+  const [documentDetail, setDocumentDetail] = useState<any>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   const fetchDocumentDetail = useCallback(async () => {
     try {
-      // Use source endpoint to get all chunks for this document
-      const data = await fetchWithAuth(`/api/admin/documents/${encodeURIComponent(source)}`)
+      // Use ID endpoint to get specific chunk
+      const data = await fetchWithAuth(`/api/admin/documents/id/${chunkId}`)
       setDocumentDetail(data)
     } catch (err: any) {
       setError(err.message)
     } finally {
       setLoading(false)
     }
-  }, [source])
+  }, [chunkId])
 
   useEffect(() => {
     fetchDocumentDetail()
@@ -88,8 +88,8 @@ export function DocumentDetail({ source, title, onClose }: DocumentDetailProps) 
         <div className="flex items-center justify-between mb-4">
           <div>
             <h2 className="text-xl font-semibold text-foreground">{title}</h2>
-            {source !== title && (
-              <p className="text-sm text-muted-foreground">{source}</p>
+            {documentDetail?.source && documentDetail.source !== title && (
+              <p className="text-sm text-muted-foreground">{documentDetail.source}</p>
             )}
           </div>
           <Button variant="ghost" size="sm" onClick={onClose}>
@@ -100,16 +100,16 @@ export function DocumentDetail({ source, title, onClose }: DocumentDetailProps) 
         <div className="mb-4 p-4 bg-muted rounded-lg">
           <div className="grid grid-cols-2 gap-4 text-sm mb-3">
             <div>
-              <strong>Chunk ID:</strong> {documentDetail?.chunks[0]?.id || 'N/A'}
+              <strong>Chunk ID:</strong> {documentDetail?.id || 'N/A'}
             </div>
             <div>
-              <strong>Content Length:</strong> {documentDetail?.chunks[0]?.content.length.toLocaleString() || 0} characters
+              <strong>Content Length:</strong> {documentDetail?.content?.length?.toLocaleString() || 0} characters
             </div>
           </div>
-          {documentDetail?.chunks[0]?.metadata && Object.keys(documentDetail.chunks[0].metadata).length > 0 && (
+          {documentDetail?.metadata && Object.keys(documentDetail.metadata).length > 0 && (
             <div className="border-t border-muted-foreground/20 pt-3">
               <div className="flex flex-wrap gap-2">
-                {Object.entries(documentDetail.chunks[0].metadata).map(([key, value]) => (
+                {Object.entries(documentDetail.metadata).map(([key, value]) => (
                   <span key={key} className="text-xs bg-background border px-2 py-1 rounded">
                     <strong>{key}:</strong> {
                       typeof value === 'object' && value !== null 
@@ -125,15 +125,15 @@ export function DocumentDetail({ source, title, onClose }: DocumentDetailProps) 
 
         <div className="flex-1 overflow-y-auto space-y-4">
           <h3 className="font-medium sticky top-0 bg-background py-2 text-foreground">Content</h3>
-          {documentDetail?.chunks.map((chunk) => (
-            <div key={chunk.id} className="border rounded-lg p-4">
+          {documentDetail?.content && (
+            <div className="border rounded-lg p-4">
               <div className="text-sm leading-relaxed prose prose-sm prose-slate dark:prose-invert max-w-none">
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                  {chunk.content}
+                  {documentDetail.content}
                 </ReactMarkdown>
               </div>
             </div>
-          ))}
+          )}
         </div>
       </div>
     </div>

--- a/components/admin/DocumentManagement.tsx
+++ b/components/admin/DocumentManagement.tsx
@@ -188,7 +188,7 @@ export function DocumentManagement() {
 
       {selectedDocument && (
         <DocumentDetail 
-          source={selectedDocument.source}
+          chunkId={selectedDocument.id.toString()}
           title={selectedDocument.title}
           onClose={() => setSelectedDocument(null)}
         />


### PR DESCRIPTION
## Summary
- Modified DocumentDetail component to fetch and display a specific chunk by ID instead of all chunks for a document source
- Updated component props to use `chunkId` instead of `source` parameter
- Changed API endpoint from `/api/admin/documents/{source}` to `/api/admin/documents/id/{chunkId}`
- Updated UI to display single chunk content rather than iterating through multiple chunks

## Test plan
- [x] Verify document detail modal opens correctly when clicking on a document in admin dashboard
- [x] Confirm specific chunk content is displayed instead of all chunks for the document
- [ ] Test with various document types to ensure content renders properly
- [ ] Verify metadata and chunk information displays correctly